### PR TITLE
fix: Call lastInsertId only if inserted_pk_value is null

### DIFF
--- a/src/Database/Recordable.php
+++ b/src/Database/Recordable.php
@@ -312,7 +312,10 @@ trait Recordable
 
         $pk_column = self::primaryKeyColumn();
         $inserted_pk_value = $values[$pk_column] ?? null;
-        $database_pk_value = $database->lastInsertId();
+        $database_pk_value = null;
+        if ($inserted_pk_value === null) {
+            $database_pk_value = $database->lastInsertId();
+        }
 
         if (is_string($inserted_pk_value) || is_int($inserted_pk_value)) {
             return $inserted_pk_value;


### PR DESCRIPTION
Pull request checklist:

- [x] code is manually tested
- [x] tests are updated
- [x] documentation is updated (including comments, commit messages, migration notes, …)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._
