### PR TITLE
new: [BC] Provide Request::paramString and change param return type

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -293,16 +293,41 @@ class Request
     }
 
     /**
-     * @template T of mixed
+     * @template T of ?string
+     *
+     * @param T $default
+     *
+     * @return string|T
+     *
+     * @see Request::paramString
+     */
+    public function param(string $name, ?string $default = null): mixed
+    {
+        return $this->paramString($name, $default);
+    }
+
+    /**
+     * @template T of ?string
      *
      * @param T $default
      *
      * @return string|T
      */
-    public function param(string $name, mixed $default = null): mixed
+    public function paramString(string $name, ?string $default = null): mixed
     {
         if (isset($this->parameters[$name])) {
-            return $this->parameters[$name];
+            $value = $this->parameters[$name];
+
+            if (
+                !is_bool($value) &&
+                !is_float($value) &&
+                !is_integer($value) &&
+                !is_string($value)
+            ) {
+                return $default;
+            }
+
+            return strval($value);
         } else {
             return $default;
         }

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -66,7 +66,7 @@ class RequestTest extends TestCase
         $this->assertSame('./cli', $request->param('bin'));
         $this->assertSame('bar', $request->param('foo'));
         $this->assertSame('qux', $request->param('foo-baz'));
-        $this->assertTrue($request->param('spam'));
+        $this->assertTrue($request->paramBoolean('spam'));
     }
 
     public function testInitFromCliWhenNoArguments(): void
@@ -163,12 +163,18 @@ class RequestTest extends TestCase
     public function testParam(): void
     {
         $request = new Request('GET', '/', [
-            'foo' => 'bar'
+            'foo' => 'bar',
+            'baz' => 42,
+            'spam' => true,
         ]);
 
         $foo = $request->param('foo');
+        $baz = $request->param('baz');
+        $spam = $request->param('spam');
 
         $this->assertSame('bar', $foo);
+        $this->assertSame('42', $baz);
+        $this->assertSame('1', $spam);
     }
 
     public function testParamWithDefaultValue(): void


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Init a request with different parameters types
2. Get parameters with `$request->param()` or `$request->paramString()`
3. Verify all the returned types are strings

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
