### PR TITLE
fix: Fix database setup when it exists but permission is denied

### DIFF
--- a/src/Migration/Controller.php
+++ b/src/Migration/Controller.php
@@ -130,12 +130,14 @@ class Controller
         $migrations_version_path = static::migrationsVersionPath();
 
         if (file_exists($schema_path)) {
-            \Minz\Database::create();
-
             $schema = @file_get_contents($schema_path);
 
             if ($schema === false) {
                 return Response::text(500, "Cannot read the database schema ({$schema_path}).");
+            }
+
+            if (!\Minz\Database::exists()) {
+                \Minz\Database::create();
             }
 
             $database = \Minz\Database::get();

--- a/tests/DatabaseTest.php
+++ b/tests/DatabaseTest.php
@@ -188,4 +188,38 @@ class DatabaseTest extends TestCase
         $this->assertSame(10, $results[0]['value']);
         $this->assertSame(30, $results[1]['value']);
     }
+
+    public function testExistsWhenDatabaseExists(): void
+    {
+        /** @var ConfigurationDatabase */
+        $configuration = Configuration::$database;
+        if ($configuration['type'] === 'sqlite') {
+            $sqlite_filename = tempnam('/tmp', 'minz-db');
+            assert($sqlite_filename !== false);
+            $configuration['path'] = $sqlite_filename;
+            Configuration::$database = $configuration;
+        }
+        Database::reset();
+
+        $exists = Database::exists();
+
+        $this->assertTrue($exists);
+    }
+
+    public function testExistsWhenDatabaseDoesNotExist(): void
+    {
+        /** @var ConfigurationDatabase */
+        $configuration = Configuration::$database;
+        if ($configuration['type'] === 'sqlite') {
+            $sqlite_filename = tempnam('/tmp', 'minz-db');
+            assert($sqlite_filename !== false);
+            $configuration['path'] = $sqlite_filename;
+            Configuration::$database = $configuration;
+        }
+        Database::drop();
+
+        $exists = Database::exists();
+
+        $this->assertFalse($exists);
+    }
 }


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

https://github.com/flusio/Flus/issues/757

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Create a database and a user with access to the database but not the permission to create one.
2. Run the "setup" command of the migrations controller
3. Verify that it works

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
